### PR TITLE
f-念靜-私人訊息刪除功能

### DIFF
--- a/slnGeeYeangSore/GeeYeangSore/Areas/Admin/Views/PrivateMessages/Index.cshtml
+++ b/slnGeeYeangSore/GeeYeangSore/Areas/Admin/Views/PrivateMessages/Index.cshtml
@@ -1,44 +1,49 @@
-﻿@*
-    For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
-*@
-@{
+﻿@{
+    ViewData["Title"] = "私人訊息管理";
 }
 
 @* 私人訊息管理頁面 *@
 @model IEnumerable<GeeYeangSore.Models.HMessage>
 
-<div class="container-fluid px-4">
-    @* 頁面標題 *@
-    <h2 class="mb-4">私人訊息管理</h2>
-
-    @* 搜尋表單 *@
-    <form method="get" class="mb-4">
-        <div class="input-group" style="max-width: 400px;">
-            @* 搜尋輸入框，使用 ViewBag.SearchString 保持搜尋條件（移除前後空白） *@
-            <input type="text" name="searchString" value="@(ViewBag.SearchString?.ToString().Trim())"
-                class="form-control" placeholder="搜尋私人訊息" />
-            <div class="input-group-append">
-                <button type="submit" class="btn btn-primary">搜尋</button>
-            </div>
+    <div class="container-fluid px-4">
+        @* 頁面標題 *@
+        <h2 class="mb-4">私人訊息管理</h2>
+        @if (TempData["SuccessMessage"] != null)
+       {
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            @TempData["SuccessMessage"]
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
-    </form>
+        }
 
-    @* 訊息列表表格 *@
-    <div class="table-responsive">
-        <table class="table table-hover">
-            <thead class="thead-light">
-                <tr>
-                    @* 表格欄位寬度設定 *@
-                    <th style="width: 15%">發送者</th>
-                    <th style="width: 15%">接收者</th>
-                    <th style="width: 40%">訊息內容</th>
-                    <th style="width: 15%">時間</th>
-                    <th style="width: 15%">操作</th>
-                </tr>
-            </thead>
-            <tbody>
-                @* 遍歷訊息列表 *@
-                @foreach (var item in Model)
+        @* 搜尋表單 *@
+        <form method="get" class="mb-4">
+            <div class="input-group" style="max-width: 400px;">
+                @* 搜尋輸入框，使用 ViewBag.SearchString 保持搜尋條件 *@
+                <input type="text" name="searchString" value="@(ViewBag.SearchString?.ToString().Trim())"
+                       class="form-control" placeholder="搜尋私人訊息" />
+                <div class="input-group-append">
+                    <button type="submit" class="btn btn-primary">搜尋</button>
+                </div>
+            </div>
+        </form>
+
+        @* 訊息列表表格 *@
+        <div class="table-responsive">
+            <table class="table table-hover">
+                <thead class="thead-light">
+                    <tr>
+                        @* 表格欄位寬度設定 *@
+                        <th style="width: 15%">發送者</th>
+                        <th style="width: 15%">接收者</th>
+                        <th style="width: 40%">訊息內容</th>
+                        <th style="width: 15%">時間</th>
+                        <th style="width: 15%">操作</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @* 遍歷訊息列表 *@
+                    @foreach (var item in Model)
                 {
                     <tr>
                         <td>@item.HSenderId (@item.HSenderRole)</td>
@@ -48,29 +53,33 @@
                         <td>
                             @* 操作按鈕 *@
                             <a class="btn btn-primary btn-sm" asp-action="Details" asp-route-id="@item.HMessageId">查看對話</a>
-                            <a class="btn btn-danger btn-sm" asp-action="Delete" asp-route-id="@item.HMessageId"
-                                onclick="return confirm('確定要刪除這條訊息嗎？');">刪除</a>
+                            <form asp-action="Delete" method="post" asp-area="Admin" asp-controller="PrivateMessages"
+                                  asp-route-id="@item.HMessageId" onsubmit="return confirm('確定要刪除這則訊息嗎？');"
+                                  style="display:inline;">
+                                @Html.AntiForgeryToken()
+                                <button type="submit" class="btn btn-danger btn-sm">刪除</button>
+                            </form>
                         </td>
                     </tr>
                 }
-            </tbody>
-        </table>
-    </div>
+                </tbody>
+            </table>
+        </div>
 
-    @* 分頁導航 *@
-    @if (ViewBag.TotalPages > 0)
+        @* 分頁導航 *@
+        @if (ViewBag.TotalPages > 0)
     {
         <nav aria-label="Page navigation" class="mt-4">
             <ul class="pagination justify-content-center">
                 @* 生成分頁按鈕，保持搜尋條件 *@
                 @for (int i = 1; i <= ViewBag.TotalPages; i++)
                 {
-                    <li class="page-item @(i == ViewBag.CurrentPage ? "active" : "")">
-                        <a class="page-link" asp-action="Index" asp-route-page="@i"
-                            asp-route-searchString="@ViewBag.SearchString">@i</a>
-                    </li>
+                <li class="page-item @(i == ViewBag.CurrentPage ? "active" : "")">
+                    <a class="page-link" asp-action="Index" asp-route-page="@i"
+                       asp-route-searchString="@ViewBag.SearchString">@i</a>
+                </li>
                 }
             </ul>
         </nav>
     }
-</div>
+    </div>


### PR DESCRIPTION
【調整】
將 [Area("Admin")] 和 [Route("[area]/[controller]/[action]")] 屬性從 Index 方法上方搬移到 SuperController 上方（影響整個控制器）

【新增】
新增「刪除訊息」功能（PrivateMessagesController.cs + View 列表刪除按鈕），能夠跳出「確認刪除?」及「刪除成功」框

【修正】
修正 PrivateMessages Index 頁面上原本不完整的註解與刪除按鈕寫法